### PR TITLE
Add missing "// +build cgo" tag to C sources

### DIFF
--- a/curl_transform.go
+++ b/curl_transform.go
@@ -1,3 +1,4 @@
+// +build cgo
 // +build linux
 
 /*

--- a/pow_c.go
+++ b/pow_c.go
@@ -1,3 +1,4 @@
+// +build cgo
 // +build linux darwin
 
 /*

--- a/pow_c_test.go
+++ b/pow_c_test.go
@@ -1,3 +1,5 @@
+//+build cgo
+
 /*
 MIT License
 


### PR DESCRIPTION
This fix allows to properly compile in a pure Go (`CGO_ENABLED=0`) environment.