### PR TITLE
Fixed bug in TestBundle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ before_install:
 - gometalinter --install --update
 
 script:
-- travis_wait 30 go test -tags=avx -v -covermode=count -coverprofile=coverage.out -timeout 100m
+- travis_wait 30 go test -tags=avx -v -covermode=count -coverprofile=coverage.out -timeout 100m -short
 
 after_success:
 - gometalinter -e bindata --deadline=1000s ./...

--- a/api_test.go
+++ b/api_test.go
@@ -28,6 +28,10 @@ package giota
 import "testing"
 
 func TestAPIGetNodeInfo(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping in short mode")
+	}
+
 	var err error
 	var resp *GetNodeInfoResponse
 
@@ -96,6 +100,10 @@ func TestAPIGetTips(t *testing.T) {
 }
 */
 func TestAPIFindTransactions(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping in short mode")
+	}
+
 	var err error
 	var resp *FindTransactionsResponse
 
@@ -118,6 +126,10 @@ func TestAPIFindTransactions(t *testing.T) {
 }
 
 func TestAPIGetTrytes(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping in short mode")
+	}
+
 	var err error
 	var resp *GetTrytesResponse
 
@@ -139,6 +151,10 @@ func TestAPIGetTrytes(t *testing.T) {
 }
 
 func TestAPIGetInclusionStates(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping in short mode")
+	}
+
 	var err error
 	var resp *GetInclusionStatesResponse
 
@@ -159,6 +175,10 @@ func TestAPIGetInclusionStates(t *testing.T) {
 }
 
 func TestAPIGetBalances(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping in short mode")
+	}
+
 	var err error
 	var resp *GetBalancesResponse
 
@@ -180,6 +200,10 @@ func TestAPIGetBalances(t *testing.T) {
 }
 
 func TestAPIGetTransactionsToApprove(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping in short mode")
+	}
+
 	var err error
 	var resp *GetTransactionsToApproveResponse
 
@@ -201,7 +225,11 @@ func TestAPIGetTransactionsToApprove(t *testing.T) {
 	}
 }
 
-func TestGetLatestInclusion(t *testing.T) {
+func TestAPIGetLatestInclusion(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping in short mode")
+	}
+
 	var err error
 	var resp []bool
 

--- a/trinary.go
+++ b/trinary.go
@@ -405,11 +405,11 @@ func (t Trytes) IsValid() error {
 func incTrits(t Trits) {
 	for j := range t {
 		t[j]++
-		switch {
-		case t[j] > 1:
-			t[j] = -1
-		default:
+
+		if t[j] <= 1 {
 			break
 		}
+
+		t[j] = -1
 	}
 }


### PR DESCRIPTION
- ~~8ae05a4~~ 8d0ffc59bc3bb4cd841cadd30581cc4db9663ae1 introduced a subtle bug that caused TestBundle to hang, incTrits() logic
reworked to fix bug and avoid unnecessary logic.

- added check for testing.Short() flag to API tests to avoid unwanted network lag when
connecting to random public nodes.

- refactored TestBundle to be table driven.